### PR TITLE
Optional Attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -57,7 +57,8 @@ public final class FindMeetingQuery {
     return availableTimesForAllAttendees;
   }
   
-  private Collection<TimeRange> getAvailableTimes(Collection<String> attendees, Collection<Event> events, long duration) {
+  private Collection<TimeRange> getAvailableTimes(Collection<String> attendees,
+        Collection<Event> events, long duration) {
     if (attendees.isEmpty()) {
       return Arrays.asList(TimeRange.WHOLE_DAY);
     }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -55,11 +55,11 @@ public final class FindMeetingQuery {
     }
     return availableTimesForAllAttendees;
   }
-  
+
   private Collection<TimeRange> getAvailableTimes(Collection<Event> events,
          Collection<String> attendees, long duration) {
     if (attendees.isEmpty()) {
-      return Arrays.asList(TimeRange.WHOLE_DAY);f
+      return Arrays.asList(TimeRange.WHOLE_DAY);
     }
 
     // Get all unavailable time ranges based on the attendees
@@ -96,12 +96,15 @@ public final class FindMeetingQuery {
     Collection<TimeRange> availableTimes = new ArrayList<>();
     for (int i = 0; i < unavailableTimes.size(); i++) {
       if (i == 0) {
-        createSlot(TimeRange.START_OF_DAY, unavailableTimes.get(i).start(), duration, availableTimes);
+        addSlotToAvailableTimesIfSlotValid(TimeRange.START_OF_DAY,
+                unavailableTimes.get(i).start(), duration, availableTimes);
       } else  {
-        createSlot(unavailableTimes.get(i - 1).end(), unavailableTimes.get(i).start(), duration, availableTimes);
+        addSlotToAvailableTimesIfSlotValid(unavailableTimes.get(i - 1).end(),
+                unavailableTimes.get(i).start(), duration, availableTimes);
       }
       if (i == unavailableTimes.size() - 1) {
-        createSlot(unavailableTimes.get(i).end(), TimeRange.END_OF_DAY, duration, availableTimes);
+        addSlotToAvailableTimesIfSlotValid(unavailableTimes.get(i).end(),
+                TimeRange.END_OF_DAY, duration, availableTimes);
       }
     }
 
@@ -117,7 +120,8 @@ public final class FindMeetingQuery {
     return false;
   }
 
-  private void createSlot(int start, int end, long duration, Collection<TimeRange> availableTimes) {
+  private void addSlotToAvailableTimesIfSlotValid(int start, int end, long duration,
+                                                  Collection<TimeRange> availableTimes) {
     if (start < end && end - start >= duration) {
       boolean inclusive = end == TimeRange.END_OF_DAY;
       availableTimes.add(TimeRange.fromStartEnd(start, end, inclusive));

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -41,10 +41,6 @@ public final class FindMeetingQuery {
     Collection<String> optionalAttendees = request.getOptionalAttendees();
     long meetingDuration = request.getDuration();
 
-    if (mandatoryAttendees.isEmpty() && optionalAttendees.isEmpty()) {
-      return Arrays.asList(TimeRange.WHOLE_DAY);
-    }
-
     if (optionalAttendees.isEmpty()) {
       return getAvailableTimes(mandatoryAttendees, events, meetingDuration);
     }
@@ -62,6 +58,10 @@ public final class FindMeetingQuery {
   }
   
   private Collection<TimeRange> getAvailableTimes(Collection<String> attendees, Collection<Event> events, long duration) {
+    if (attendees.isEmpty()) {
+      return Arrays.asList(TimeRange.WHOLE_DAY);
+    }
+
     // Get all unavailable time ranges based on the attendees
     List<TimeRange> unavailableTimes = new LinkedList<>();
     for (Event event: events) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -63,7 +63,7 @@ public final class FindMeetingQuery {
     }
 
     // Get all unavailable time ranges based on the attendees
-    List<TimeRange> unavailableTimes = new LinkedList<>();
+    List<TimeRange> unavailableTimes = new ArrayList<>();
     for (Event event: events) {
       if (containsAtLeastOneAttendee(event, attendees)) {
         unavailableTimes.add(event.getWhen());

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,25 +41,25 @@ public final class FindMeetingQuery {
     long meetingDuration = request.getDuration();
 
     if (optionalAttendees.isEmpty()) {
-      return getAvailableTimes(mandatoryAttendees, events, meetingDuration);
+      return getAvailableTimes(events, mandatoryAttendees, meetingDuration);
     }
 
     Collection<String> allAttendees = Stream.
             concat(mandatoryAttendees.stream(), optionalAttendees.stream()).
             collect(Collectors.toList());
 
-    Collection<TimeRange> availableTimesForAllAttendees = getAvailableTimes(allAttendees, events, meetingDuration);
+    Collection<TimeRange> availableTimesForAllAttendees = getAvailableTimes(events, allAttendees, meetingDuration);
 
     if (availableTimesForAllAttendees.isEmpty()) {
-      return getAvailableTimes(mandatoryAttendees, events, meetingDuration);
+      return getAvailableTimes(events, mandatoryAttendees, meetingDuration);
     }
     return availableTimesForAllAttendees;
   }
   
-  private Collection<TimeRange> getAvailableTimes(Collection<String> attendees,
-        Collection<Event> events, long duration) {
+  private Collection<TimeRange> getAvailableTimes(Collection<Event> events,
+         Collection<String> attendees, long duration) {
     if (attendees.isEmpty()) {
-      return Arrays.asList(TimeRange.WHOLE_DAY);
+      return Arrays.asList(TimeRange.WHOLE_DAY);f
     }
 
     // Get all unavailable time ranges based on the attendees
@@ -95,14 +94,14 @@ public final class FindMeetingQuery {
 
     // Create slots between unavailable time ranges
     Collection<TimeRange> availableTimes = new ArrayList<>();
-    for (int idx = 0; idx < unavailableTimes.size(); idx++) {
-      if (idx == 0) {
-        createSlot(TimeRange.START_OF_DAY, unavailableTimes.get(idx).start(), duration, availableTimes);
+    for (int i = 0; i < unavailableTimes.size(); i++) {
+      if (i == 0) {
+        createSlot(TimeRange.START_OF_DAY, unavailableTimes.get(i).start(), duration, availableTimes);
       } else  {
-        createSlot(unavailableTimes.get(idx - 1).end(), unavailableTimes.get(idx).start(), duration, availableTimes);
+        createSlot(unavailableTimes.get(i - 1).end(), unavailableTimes.get(i).start(), duration, availableTimes);
       }
-      if (idx == unavailableTimes.size() - 1) {
-        createSlot(unavailableTimes.get(idx).end(), TimeRange.END_OF_DAY, duration, availableTimes);
+      if (i == unavailableTimes.size() - 1) {
+        createSlot(unavailableTimes.get(i).end(), TimeRange.END_OF_DAY, duration, availableTimes);
       }
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -25,13 +25,13 @@ import java.util.stream.Stream;
 
 public final class FindMeetingQuery {
   /*
-   * 1. If one or more time slots exists so that both mandatory and optional attendees can attend,
-   *                                              returns those time slots.
+   * Returns available slots for a meeting. If one or more time slots exist so that both mandatory
+   * and optional attendees can attend, returns those time slots. Otherwise, returns the time slots
+   * that fit mandatory attendees.
    *
-   * 2. Otherwise, returns the time slots that fit just the mandatory attendees.
-   *
-   * Parameters: events (all events that are in the calendar, some of them could not relate
-   *                      to the attendees in the meeting request) */
+   * @param events All existing events in the calendar
+   * @param request {@link MeetingRequest} object with the request details
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       return Arrays.asList();

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,7 +14,6 @@
 
 package com.google.sps;
 
-import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,6 +35,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +45,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -267,6 +270,171 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noIntersectionWithOptional() {
+    // Have mandatory attendees different events, but they have 3 slots for the meeting.
+    // Optional attendee is busy the whole day, so slots that fit just the mandatory
+    // attendees are returned
+    //
+    // Mandatory: A, B
+    // Optional : C
+    // Events  :       |--A--|     |--B--|
+    //           |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()),
+                    Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void mandatoryAndOptionalCanAttend() {
+    // If one or more time slots exists so that both mandatory
+    // and optional attendees can attend, return them.
+    //
+    // Mandatory: A, B
+    // Optional : C
+    // Events  :       |--A--|     |--B--|
+    //                       |--C--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomOptionalIsIgnored() {
+    // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting. Optional attendee should be ignored since considering
+    // their schedule would result in a time slot smaller than the requested time.
+    //
+    // Mandatory: A
+    // Optional : B
+    // Events  : |--A--|     |----A----|
+    //                 |-B-|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+                    Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryOnlyOptional() {
+    // No mandatory attendees, just two optional attendees with several gaps
+    // in their schedules. Those gaps should be identified and returned.
+    //
+    // Mandatory: None
+    // Optional : A, B
+    // Events  :       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAndOptionalAreBusy() {
+    // No mandatory attendees, just two optional attendees with no gaps
+    // in their schedules. The whole day should be returned
+    //
+    // Mandatory: None
+    // Optional : A, B
+    // Events  : |---------------A-------------|
+    //           |---B---||--------B-----------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.fromStartEnd(TIME_0800AM, TimeRange.END_OF_DAY, true),
+                    Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -277,7 +277,7 @@ public final class FindMeetingQueryTest {
   public void noIntersectionWithOptional() {
     // Have mandatory attendees different events, but they have 3 slots for the meeting.
     // Optional attendee is busy the whole day, so slots that fit just the mandatory
-    // attendees are returned
+    // attendees are returned.
     //
     // Mandatory: A, B
     // Optional : C
@@ -310,8 +310,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void mandatoryAndOptionalCanAttend() {
-    // If one or more time slots exists so that both mandatory
-    // and optional attendees can attend, return them.
+    // One or more time slots exists so that both mandatory
+    // and optional attendees can attend, so return them.
     //
     // Mandatory: A, B
     // Optional : C
@@ -343,7 +343,7 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void justEnoughRoomOptionalIsIgnored() {
-    // Have one person, but make it so that there is just enough room at one point in the day to
+    // Have one mandatory person, but make it so that there is just enough room at one point in the day to
     // have the meeting. Optional attendee should be ignored since considering
     // their schedule would result in a time slot smaller than the requested time.
     //
@@ -406,7 +406,7 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void noMandatoryAndOptionalAreBusy() {
+  public void noMandatoryButOptionalAreBusy() {
     // No mandatory attendees, just two optional attendees with no gaps
     // in their schedules. The whole day should be returned
     //
@@ -415,7 +415,7 @@ public final class FindMeetingQueryTest {
     // Events  : |---------------A-------------|
     //           |---B---||--------B-----------|
     // Day     : |-----------------------------|
-    // Options : |--1--|     |--2--|     |--3--|
+    // Options : |-----------------------------|
 
     Collection<Event> events = Arrays.asList(
             new Event("Event 1", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()),


### PR DESCRIPTION
Write 5 tests that take into account optional attendees

Implement support for optional attendees in `query()`:
1. If one or more time slots exists so that both mandatory and optional attendees can attend, returns those time slots.
2. Otherwise, returns the time slots that fit just the mandatory attendees.

